### PR TITLE
Fix/routes precedence

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const extractSass = require('./extractSass.webpack')
 
 const paths = {
   src: path.join(__dirname, '..', 'src')
@@ -15,6 +14,9 @@ const config = {
       store: path.join(paths.src, 'store'),
       utils: path.join(paths.src, 'utils')
     }
+  },
+  output: {
+    publicPath: '/'
   },
   devServer: {
     historyApiFallback: true

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -68,6 +68,7 @@ const config = {
     runtimeChunk: true
   },
   output: {
+    ...baseConfig.output,
     filename: 'js/[name]_[chunkhash].js'
   }
 }

--- a/src/components/form/styles/LoginForm.style.js
+++ b/src/components/form/styles/LoginForm.style.js
@@ -1,5 +1,5 @@
 import styled from 'react-emotion'
 
-export const Form = styled('div')`
+export const Form = styled('form')`
   background: #F1F1F1;
 `

--- a/src/pages/NotFoundPage.js
+++ b/src/pages/NotFoundPage.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const HomePage = () => <h1>Not Found!</h1>
+
+export default HomePage

--- a/src/pages/__tests__/NotFoundPage.test.js
+++ b/src/pages/__tests__/NotFoundPage.test.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import NotFoundPage from '../NotFoundPage'
+
+const wrapper = shallow(<NotFoundPage />)
+
+describe('(Component) NotFoundPage', () => {
+  it('renders without crash', () => {
+    expect(wrapper).toHaveLength(1)
+  })
+})

--- a/src/routes/Routes.js
+++ b/src/routes/Routes.js
@@ -1,12 +1,22 @@
+/**
+ * TODO: Decouple this component:
+ * This file is a React Router 4 wrapper. It has a impure component
+ * because it's  highly coupled to route configs and Login and NotFoundPage Components.
+ * Can it will be an library in a not far distant future?
+ *
+ * TODO: Write some case tests for logged and not logged case
+ */
+
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-
 import { Switch, Route, Redirect, withRouter } from 'react-router-dom'
-import { privateRoutes, publicRoutes, notLoggedRoutes } from './pathUrls'
+import reverse from 'lodash/reverse'
 
+import { privateRoutes, publicRoutes, notLoggedRoutes } from './pathUrls'
 import RouteWithTemplate from './RouteWithTemplate'
 import LoginPage from '../pages/LoginPage'
+import NotFoundPage from '../pages/NotFoundPage'
 
 const mapStateToProps = state => {
   return {
@@ -19,7 +29,7 @@ const Routes = ({ isLogged }) => {
 
   const setRoute = route =>
     route.template ? (
-      <RouteWithTemplate {...route} key={route.path} />
+      <RouteWithTemplate {...route} key={route.path} exact />
     ) : (
       <Route key={route.path} {...route} exact />
     )
@@ -28,11 +38,13 @@ const Routes = ({ isLogged }) => {
    * This preserves the path for redirect to wished page after login
    * @param {*} route
    */
-  const setPrivateRoute = route =>
-    setRoute({
+  const setPrivateRoute = route => {
+    return setRoute({
       ...route,
+      template: isLogged ? route.template : undefined,
       component: isLogged ? route.component : LoginPage
     })
+  }
 
   const setRedirect = route => (
     <Redirect
@@ -43,11 +55,27 @@ const Routes = ({ isLogged }) => {
     />
   )
 
+  const routesPrecedence = [
+    privateRoutes.map(setPrivateRoute),
+    notLoggedRoutes.map(isLogged ? setRedirect : setRoute),
+    publicRoutes.map(setRoute)
+  ]
+
+  /**
+   * Two precedence rules:
+   * 1 - User is Logged: Private Routes > Public Routes
+   * 2 - User is Not Logged: Public Routes > Not Logged Routes > Private Routes
+   *
+   * These two rules allow overwrites on direction of user status, easing the route configuration.
+   */
+  const routes = isLogged
+    ? routesPrecedence
+    : reverse(routesPrecedence)
+
   return (
     <Switch>
-      {notLoggedRoutes.map(isLogged ? setRedirect : setRoute)}
-      {publicRoutes.map(setRoute)}
-      {privateRoutes.map(setPrivateRoute)}
+      {routes}
+      <Route component={NotFoundPage} />
     </Switch>
   )
 }

--- a/src/routes/pathUrls.js
+++ b/src/routes/pathUrls.js
@@ -1,40 +1,69 @@
-import Login from '../pages/LoginPage'
-import Home from '../pages/HomePage'
+import React from 'react'
 
 import DashboardTemplate from '../components/template/DashboardTemplate'
 
-/**
- * Only not logged users can access these routes
- */
-export const notLoggedRoutes = [
-  {
-    path: '/login',
-    component: Login
-  }
-]
-
-/**
- * Both logged and not logged users can access these routes
- */
-export const publicRoutes = [
-  {
-    path: '/',
-    component: Home
-  }
-]
+import Login from '../pages/LoginPage'
+import Home from '../pages/HomePage'
 
 /**
  * Only logged users can access these routes
+ *
+ * - Major precedence when user IS LOGGED:
+ *    Overwrites the same paths of the public routes
+ * - No match when user IS NOT LOGGED:
+ *    Render LoginPage component by default
  */
 export const privateRoutes = [
   {
-    path: '/private',
+    path: '/private1',
     component: Home,
     template: DashboardTemplate,
     default: true
   },
   {
     path: '/private2',
+    component: () => <p>private version of /private2</p>
+  },
+  {
+    path: '/private3',
+    component: () => <p>private version of /private3</p>
+  }
+]
+
+/**
+ * Only not logged users can access these routes
+ *
+ * - Precedence over same paths of private routes when user IS NOT LOGGED:
+ *    Overwrites the login rendering
+ * - No match when user IS LOGGED
+ *    Redirect to default private route
+ */
+export const notLoggedRoutes = [
+  {
+    path: '/login',
+    component: Login
+  },
+  {
+    path: '/private2',
+    component: () => <p>Not logged version</p>
+  }
+]
+
+/**
+ * Both logged and not logged users can access these routes
+ *
+ * - Minor precedence when user IS LOGGED
+ *    Is overwritten by the private route with same paths
+ * - Major precedence when user IS NOT LOGGED
+ *    Overwrites the same paths of the private and not logged routes
+ */
+export const publicRoutes = [
+  {
+    path: '/',
     component: Home
+  },
+  {
+    path: '/private3',
+    component: () => <p>public version</p>
   }
 ]


### PR DESCRIPTION
The route precedence is very important and **must be dynamic**! When the user is not logged the public routes is more important than others and **must overwrite** others types of routes with the **same path**. Otherwise, the private routes must have priority. 

An example: The Facebook has a different page for each user status at same route. When the user is logged, then Facebook shows de feed of timeline in the root path, when the user is not logged, the Facebook shows the sign in/up page. This PR improve the route rules for make this easily possible. :)

I put the precedence rule logic into `Route.js`, line 71:

```javascript
/**
   * Two precedence rules:
   * 1 - User is Logged: Private Routes > Public Routes
   * 2 - User is Not Logged: Public Routes > Not Logged Routes > Private Routes
   *
   * These two rules allow overwrites on direction of user status, easing the route configuration.
   */
  const routes = isLogged
    ? routesPrecedence
    : reverse(routesPrecedence)
```

Did:
- [x] Add rules for the dynamic route precedence.
- [x] Fix the login form submit
- [x] Document the rules of the route files
- [ ] Write test to the `Route.js`
- [ ] Decouple the `Route.js` from the route config and a lot of components

At soon I'll create a proposal to extract the `Route.js` to a library. It will ease the route update in others projects created from here.